### PR TITLE
Feat: User Registration with Groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rstest",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_with",
@@ -2266,6 +2267,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ jsonwebtoken = "9.3.1"
 serde_with = "3.14.0"
 hex = "0.4.3"
 futures = "0.3.31"
+secrecy = { version = "0.10.3", features = ["serde"] }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/hurl.env
+++ b/hurl.env
@@ -1,0 +1,8 @@
+# replace with a user credential with superadmin group
+admin_email=hurl@example.com
+admin_username="Hurlmanda Whurler"
+admin_password="hurl12345"
+
+group_user_email=grouphurl@example.com
+group_user_username="Phurl Whurlker"
+group_user_password="hurl12345"

--- a/hurl/admin.hurl
+++ b/hurl/admin.hurl
@@ -1,0 +1,54 @@
+# Setup - Create Admin
+POST http://localhost:3000/api/login
+Content-Type: application/json
+{
+  "identity": "{{admin_email}}",
+  "password": "{{admin_password}}"
+}
+HTTP 200
+[Captures]
+token: jsonpath "$['token']"
+
+# Test - Create user without group
+POST http://localhost:3000/api/admin/user
+Content-Type: application/json
+Authorization: Bearer {{token}}
+{
+  "email": "{{newUuid}}@example.com",
+  "username": "{{group_user_username}}{{newDate}}",
+  "password": "{{group_user_password}}"
+}
+HTTP 201
+[Asserts]
+# should belong to user group by default
+jsonpath "$.groups" count == 1
+jsonpath "$.groups[0]" == "users"
+
+# Test - Create user with invalid group
+POST http://localhost:3000/api/admin/user
+Content-Type: application/json
+Authorization: Bearer {{token}}
+{
+  "email": "{{newUuid}}@example.com",
+  "username": "{{group_user_username}}{{newDate}}",
+  "password": "{{group_user_password}}",
+  "groups": ["invalid"]
+}
+HTTP 400
+`invalid group specified: \`invalid\``
+
+# Test - Create user with valid group
+POST http://localhost:3000/api/admin/user
+Content-Type: application/json
+Authorization: Bearer {{token}}
+{
+  "email": "{{newUuid}}@example.com",
+  "username": "{{group_user_username}}{{newDate}}",
+  "password": "{{group_user_password}}",
+  "groups": ["superadmin"]
+}
+HTTP 201
+[Asserts]
+# should have `superadmin` group
+jsonpath "$.groups" count == 1
+jsonpath "$.groups[0]" == "superadmin"

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,1 @@
+pub mod user;

--- a/src/domain/user.rs
+++ b/src/domain/user.rs
@@ -1,0 +1,73 @@
+use regex::Regex;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+#[derive(Debug, Clone)]
+pub struct Email(String);
+
+impl TryFrom<&str> for Email {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let email_re = Regex::new(r"^[\w.+-]+@[\w-]+\.[\w.-]+$").unwrap();
+        if !email_re.is_match(value) {
+            anyhow::bail!("invalid email");
+        }
+        Ok(Self(value.to_owned()))
+    }
+}
+
+impl<'de> Deserialize<'de> for Email {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let email = String::deserialize(deserializer)?;
+        Ok(Self::try_from(email.as_str()).map_err(|e| serde::de::Error::custom(e.to_string()))?)
+    }
+}
+
+impl ToString for Email {
+    fn to_string(&self) -> String {
+        self.0.to_owned()
+    }
+}
+
+impl AsRef<str> for Email {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Password(SecretString);
+
+impl TryFrom<&str> for Password {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if value.len() < 8 {
+            anyhow::bail!("password too short");
+        }
+
+        Ok(Self(SecretString::from(value)))
+    }
+}
+
+impl<'de> Deserialize<'de> for Password {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let password = String::deserialize(deserializer)?;
+
+        Ok(Self::try_from(password.as_str())
+            .map_err(|e| serde::de::Error::custom(e.to_string()))?)
+    }
+}
+
+impl Password {
+    pub fn expose(&self) -> &str {
+        self.0.expose_secret()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod domain;
 pub mod handler;
 pub mod repository;
 pub mod services;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use tokio::net::TcpListener;
 use tower_http::services::ServeDir;
 
 mod api;
+mod domain;
 mod handler;
 mod repository;
 mod services;
@@ -79,6 +80,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/refresh-token", post(api::auth::refresh_token_api))
         .route("/api/me", get(api::auth::me_api))
         .route("/api/change-password", post(api::auth::change_password_api))
+        .route("/api/admin/user", post(api::admin::create_user))
         // se seu middleware precisa de Extensions (jwt_service, pool, user_service),
         // assegure-se de aplicar essas Extensions ANTES do middleware nesta sub-árvore:
         .layer(Extension(jwt_service.clone()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,6 @@ async fn main() -> anyhow::Result<()> {
         .layer(Extension(jwt_service.clone()))
         .layer(Extension(user_service.clone()))
         .layer(Extension(pool.clone()));
-    // .layer(from_fn(require_superadmin));
     let app = Router::new()
         // Pages
         .merge(public_router)

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("  • Health: /api/health, /api/health/ready, /api/health/live");
     tracing::info!("  • Public: /login, /register, /reset-password");
     tracing::info!("  • Protected: /dashboard, /change-password");
-    tracing::info!("  • API: /api/login, /api/register, /api/me, /api/refresh-token");
+    tracing::info!("  • API: /api/login, /api/register, /api/me, /api/refresh-token, /api/admin/user");
 
     axum::serve(listener, app).await.unwrap();
 

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -153,6 +153,19 @@ pub trait GroupRepository: Send + Sync + 'static {
         group_id: i64,
         assigned_by: Option<i64>,
     ) -> Result<()>;
+    async fn assign_user_to_groups(
+        &self,
+        user_id: i64,
+        group_ids: &[i64],
+        assigned_by: Option<i64>,
+    ) -> Result<()> {
+        for group_id in group_ids {
+            let _ = self
+                .assign_user_to_group(user_id, *group_id, assigned_by)
+                .await?;
+        }
+        Ok(())
+    }
     async fn remove_user_from_group(&self, user_id: i64, group_id: i64) -> Result<()>;
     async fn get_group_policies(&self, group_id: i64) -> Result<Vec<Policy>>;
 }

--- a/src/services/user_service.rs
+++ b/src/services/user_service.rs
@@ -1,3 +1,4 @@
+use crate::domain::user::{Email, Password};
 use crate::repository::{
     GroupRepository, NewPasswordResetToken, NewUser, PasswordResetRepository, UserRepository,
 };
@@ -24,6 +25,14 @@ pub struct UserResponse {
     pub password_hash: String,
     pub groups: Vec<String>,
     pub first_login: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateUserRequest {
+    pub email: Email,
+    pub username: String,
+    pub password: Password,
+    pub groups: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -82,20 +91,21 @@ impl<U: UserRepository, G: GroupRepository, P: PasswordResetRepository> UserServ
         }
     }
 
-    pub async fn register(&self, req: RegisterRequest) -> Result<AuthResponse> {
-        // Validations
-        let email_re = Regex::new(r"^[\w.+-]+@[\w-]+\.[\w.-]+$").unwrap();
-        if !email_re.is_match(&req.email) {
-            return Err(anyhow!("invalid email"));
-        }
-        if req.password.len() < 8 {
-            return Err(anyhow!("password too short"));
-        }
-
+    pub async fn create_user(
+        &self,
+        req: CreateUserRequest,
+        admin_id: Option<i64>,
+    ) -> Result<UserResponse> {
         // Check uniqueness
-        if self.user_repo.find_by_email(&req.email).await?.is_some() {
+        if self
+            .user_repo
+            .find_by_email(req.email.as_ref())
+            .await?
+            .is_some()
+        {
             return Err(anyhow!("email already registered"));
         }
+
         if self
             .user_repo
             .find_by_username(&req.username)
@@ -105,12 +115,14 @@ impl<U: UserRepository, G: GroupRepository, P: PasswordResetRepository> UserServ
             return Err(anyhow!("username taken"));
         }
 
+        let group_ids = self.into_group_ids(&req.groups).await?;
+
         // Hash password
-        let password_hash = self.hash_password(&req.password)?;
+        let password_hash = self.hash_password(req.password.expose())?;
 
         let new_user = NewUser {
             external_id: Uuid::new_v4(),
-            email: req.email,
+            email: req.email.to_string(),
             username: req.username,
             password_hash,
             first_login: false,
@@ -118,37 +130,53 @@ impl<U: UserRepository, G: GroupRepository, P: PasswordResetRepository> UserServ
 
         let user = self.user_repo.insert_user(new_user).await?;
 
-        // Assign to 'users' group by default
-        if let Ok(Some(users_group)) = self.group_repo.find_by_name("users").await {
-            let _ = self
-                .group_repo
-                .assign_user_to_group(user.user_id, users_group.group_id, None)
-                .await;
-        }
+        self.group_repo
+            .assign_user_to_groups(user.user_id, &group_ids[..], admin_id)
+            .await?;
 
         // Get user groups for JWT
         let groups = self.get_user_group_names(user.user_id).await?;
+
+        Ok(UserResponse {
+            user_id: user.user_id,
+            external_id: user.external_id,
+            email: user.email,
+            username: user.username,
+            password_hash: user.password_hash,
+            groups,
+            first_login: user.first_login,
+        })
+    }
+
+    pub async fn register(&self, req: RegisterRequest) -> Result<AuthResponse> {
+        // creat user
+        let user = self
+            .create_user(
+                CreateUserRequest {
+                    email: Email::try_from(req.email.as_str())?,
+                    username: req.username,
+                    password: Password::try_from(req.password.as_str())?,
+                    // Assign to 'users' group by default
+                    groups: vec!["users".to_string()],
+                },
+                None,
+            )
+            .await?;
 
         // Generate JWT token
         let token = self.jwt_service.generate_token(
             user.user_id,
             &user.email,
             &user.username,
-            groups.clone(),
+            user.groups.clone(),
         )?;
 
+        let requires_password_change = user.first_login;
+
         Ok(AuthResponse {
-            user: UserResponse {
-                user_id: user.user_id,
-                external_id: user.external_id,
-                email: user.email,
-                username: user.username,
-                password_hash: user.password_hash,
-                groups,
-                first_login: user.first_login,
-            },
+            user,
             token,
-            requires_password_change: user.first_login,
+            requires_password_change,
         })
     }
 
@@ -336,6 +364,20 @@ impl<U: UserRepository, G: GroupRepository, P: PasswordResetRepository> UserServ
 
     pub async fn cleanup_expired_tokens(&self) -> Result<()> {
         self.password_reset_repo.cleanup_expired_tokens().await
+    }
+
+    async fn into_group_ids(&self, groups: &Vec<String>) -> Result<Vec<i64>> {
+        let mut group_ids = Vec::new();
+
+        for group in groups {
+            if let Ok(Some(users_group)) = self.group_repo.find_by_name(&group).await {
+                group_ids.push(users_group.group_id);
+            } else {
+                return Err(anyhow!("invalid group specified: `{}`", group));
+            }
+        }
+
+        Ok(group_ids)
     }
 }
 

--- a/tests/user_services_test.rs
+++ b/tests/user_services_test.rs
@@ -498,7 +498,8 @@ async fn admin_create_user_with_groups() {
                 username: "admin".to_string(),
                 password: Password::try_from("Password123").unwrap(),
                 // Assign to 'superadmin' group by default
-                groups: vec!["superadmin".to_string()],
+                groups: Some(vec!["superadmin".to_string()]),
+                first_login: false,
             },
             None,
         )
@@ -524,7 +525,8 @@ async fn admin_create_user_with_groups() {
                 email: Email::try_from("testuser@example.com").unwrap(),
                 username: "testuser".to_string(),
                 password: Password::try_from("Password123").unwrap(),
-                groups: vec!["users".to_string(), test_group.name],
+                groups: Some(vec!["users".to_string(), test_group.name]),
+                first_login: false,
             },
             Some(superadmin.user_id),
         )
@@ -543,7 +545,8 @@ async fn admin_create_user_with_groups() {
                 email: Email::try_from("testuser2@example.com").unwrap(),
                 username: "testuser2".to_string(),
                 password: Password::try_from("Password123").unwrap(),
-                groups: vec!["users".to_string(), "invalid".to_string()],
+                groups: Some(vec!["users".to_string(), "invalid".to_string()]),
+                first_login: false,
             },
             Some(superadmin.user_id),
         )


### PR DESCRIPTION
Introduce `POST /api/admin/user` endpoint allowing administrators to create a new user by providing username, email, password, and optionally assigning the user to one or more groups. On success, the API returns the created user’s details along with the list of groups.

Refactor user creation logic by extracting the user persistence code from the existing `register` function into a reusable `create_user` method, which is now used both by the register endpoint and the new admin endpoint. Move email and password validation into dedicated domain value objects to enable early validation during deserialization.

Add tests to confirm:
- admin can create users with valid groups and receives the expected group list
- invalid group assignment fails with an appropriate error

Closes #7