### PR TITLE
docs: fixed dev setup with sqlx and docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ target/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-.env
+.idea/
+*.env
+*.sqlx/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,31 +61,39 @@ Feature requests are discussed openly and may be implemented collaboratively.
 Follow these steps to get KeyRunes running locally:
 
 1. **Clone the repository:**
-   ```bash
-   git clone https://github.com/jonatasoli/keyrunes.git
-   cd keyrunes
+```bash
+   git clone https://github.com/jonatasoli/keyrunes.git && cd keyrunes
+```
 
 Start the database and services using Docker Compose:
 
+Create a file named `.env` This allows docker compose to pick up env vars instead of manually passing them in the cli command everytime.
+Setup your env variables with values using .env-example` file listed in the main directory as an example.
+
+Run the below to create db tables / migrations
 ```bash
-docker-compose up
+   sqlx migrate run 
+```
+
+Run the below
+```bash
+   docker-compose up
 ```
 
 Run the web application:
 
 ```bash
-cargo run --bin keyrunes
-
+   cargo run --bin keyrunes
 ```
 
 Run the CLI application:
 ```bash
-cargo run --bin cli
+   cargo run --bin cli
 ```
 
 Run tests:
 ```bash
-cargo test
+  cargo test 
 ```
 
 Code Style and Standards
@@ -101,7 +109,7 @@ Keep code modular and well-documented.
 Use Clippy to catch warnings:
 
 ```bash
-cargo clippy
+  cargo clippy
 ```
 
 Submitting Pull Requests
@@ -128,4 +136,3 @@ Community Guidelines
 - Stay on-topic and avoid off-topic discussions in issues/PRs.
 
 - Follow the [Code of Conduct](CODE_OF_CONDUCT.md)
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     ports:
-      - "${POSTGRES_PORT}:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - keyrunes_postgres_data:/var/lib/postgresql/data
     restart: unless-stopped


### PR DESCRIPTION
documented the below when running  `cargo  sqlx prepare`


```
cargo sqlx prepare
    Checking keyrunes v0.1.0 (/home/test/Desktop/rust/keyrunes)
error: error returned from database: relation "users" does not exist
  --> src/api/admin.rs:63:27
   |
63 |     let user_count: i64 = sqlx::query_scalar!("SELECT COUNT(*) FROM users")
   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro $crate::sqlx_macros::expand_query which comes from the expansion of the macro sqlx::query_scalar (in Nightly builds, run with -Z macro-backtrace for more info)
error: error returned from database: relation "groups" does not exist
  --> src/api/admin.rs:69:28
  ```
  
  Also fixes the below rendering in RustRover
  
  
<img width="735" height="165" alt="image" src="https://github.com/user-attachments/assets/148db840-03cc-4ff8-a1f6-0ba1259b5cec" />
